### PR TITLE
remove QL from build to verify root cause

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,16 +42,16 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: "Initialize CodeQL for ${{ matrix.language }} ${{ matrix.project }}"
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # config: |
-        #     paths:
-        #       - src/${{ matrix.project }}
-        #       - src/WUPHF.Shared
+    # # Initializes the CodeQL tools for scanning.
+    # - name: "Initialize CodeQL for ${{ matrix.language }} ${{ matrix.project }}"
+    #   uses: github/codeql-action/init@v3
+    #   with:
+    #     languages: ${{ matrix.language }}
+    #     build-mode: ${{ matrix.build-mode }}
+    #     # config: |
+    #     #     paths:
+    #     #       - src/${{ matrix.project }}
+    #     #       - src/WUPHF.Shared
 
     - if: matrix.language == 'csharp'
       uses: actions/setup-dotnet@v4
@@ -87,8 +87,8 @@ jobs:
         dotnet restore src/${{ matrix.project }}
         dotnet build src/${{ matrix.project }}
 
-    - name: "Perform CodeQL Analysis for ${{ matrix.language }} ${{ matrix.project }}"
-      uses: github/codeql-action/analyze@v3
-      with:
-        # Adds /project:{project} to the category if <project> is set in the matrix
-        category: "/language:${{matrix.language}}${{ matrix.project && format('/project:{0}', matrix.project) || '' }}"
+    # - name: "Perform CodeQL Analysis for ${{ matrix.language }} ${{ matrix.project }}"
+    #   uses: github/codeql-action/analyze@v3
+    #   with:
+    #     # Adds /project:{project} to the category if <project> is set in the matrix
+    #     category: "/language:${{matrix.language}}${{ matrix.project && format('/project:{0}', matrix.project) || '' }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
           build-mode: manual
         - project: WUPHF.Mobile
           language: csharp
-          build-mode: none # Using none mode to avoid a linux android SDK and windows CodeQL path too long issue here :sigh:
+          build-mode: manual
         - project: WUPHF.Web
           language: csharp
           build-mode: manual


### PR DESCRIPTION
Base Test - CodeQL BMN = Success

Test 1 - No CodeQL = Success
- See run: https://github.com/dotnet-felickz/monorepo/actions/runs/17338747699/job/49229586735

Test 2 - CodeQL Manual = Fail