### PR TITLE
Update CodeQL workflow for WUPHF.Mobile project to always restore wor…

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,21 +54,21 @@ jobs:
       run: |
         dotnet workload restore src/WUPHF.Mobile/WUPHF.Mobile.csproj
 
-        # if (-not (dotnet workload list | Select-String "maui-android")) {
-        #     dotnet workload install maui-android --skip-manifest-update
-        # }
-        # if (-not (dotnet workload list | Select-String "maui-ios")) {
-        #     dotnet workload install maui-ios --skip-manifest-update
-        # }
-        # if (-not (dotnet workload list | Select-String "maui-maccatalyst")) {
-        #     dotnet workload install maui-maccatalyst --skip-manifest-update
-        # }
-        # if (-not (dotnet workload list | Select-String "maui-windows")) {
-        #     dotnet workload install maui-windows --skip-manifest-update
-        # }
-        # if (-not (dotnet workload list | Select-String "maui-tizen ")) {
-        #     dotnet workload install maui-tizen  --skip-manifest-update
-        # }
+        if (-not (dotnet workload list | Select-String "maui-android")) {
+            dotnet workload install maui-android --skip-manifest-update
+        }
+        if (-not (dotnet workload list | Select-String "maui-ios")) {
+            dotnet workload install maui-ios --skip-manifest-update
+        }
+        if (-not (dotnet workload list | Select-String "maui-maccatalyst")) {
+            dotnet workload install maui-maccatalyst --skip-manifest-update
+        }
+        if (-not (dotnet workload list | Select-String "maui-windows")) {
+            dotnet workload install maui-windows --skip-manifest-update
+        }
+        if (-not (dotnet workload list | Select-String "maui-tizen ")) {
+            dotnet workload install maui-tizen  --skip-manifest-update
+        }
 
     # CodeQL Init
     - name: "Initialize CodeQL for ${{ matrix.language }} ${{ matrix.project }}"


### PR DESCRIPTION
Improving

> Low C# analysis quality
> [View workflow run](https://github.com/dotnet-felickz/monorepo/actions/runs/18470449290)
> Scanning C# code completed successfully, but the scan encountered issues. This may be caused by problems identifying dependencies or use of generated source code. Some metrics of the database quality are: Percentage of calls with call target: 55 % (threshold 85 %). Percentage of expressions with known type: 68 % (threshold 85 %). Ideally these metrics should be above their thresholds. Addressing these issues is advisable to avoid false-positives or missing results. If they cannot be addressed, consider scanning C# using either the autobuild or manual [build modes](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages#comparison-of-the-build-modes).

from 55 to 56% coverage with build mode none